### PR TITLE
Fix start time when buffer is repeated.

### DIFF
--- a/soapypower/power.py
+++ b/soapypower/power.py
@@ -252,7 +252,8 @@ class SoapyPower:
             logger.debug('    Repeat: {}'.format(repeat + 1))
             # Read samples from SDR in main thread
             t_acq = time.time()
-            acq_time_start = datetime.datetime.utcnow()
+            if repeat == 0:
+                acq_time_start = datetime.datetime.utcnow()
             self.device.read_stream_into_buffer(self._buffer)
             acq_time_stop = datetime.datetime.utcnow()
             t_acq_end = time.time()


### PR DESCRIPTION
@xmikos this fixes a bug where incorrect start times are written when the integration buffer exceeds the max buffer size