### PR TITLE
Handle stream exceptions gracefully

### DIFF
--- a/soapypower/power.py
+++ b/soapypower/power.py
@@ -253,7 +253,14 @@ class SoapyPower:
             # Read samples from SDR in main thread
             t_acq = time.time()
             acq_time_start = datetime.datetime.utcnow()
-            self.device.read_stream_into_buffer(self._buffer)
+
+            try:
+                self.device.read_stream_into_buffer(self._buffer)
+            except RuntimeError as e:
+                global _shutdown
+                logger.error('      RuntimeError while reading stream: {}'.format(e))
+                _shutdown = True
+
             acq_time_stop = datetime.datetime.utcnow()
             t_acq_end = time.time()
             logger.debug('      Acquisition time: {:.3f} s'.format(t_acq_end - t_acq))


### PR DESCRIPTION
By catching stream exceptions, this patch ensures the data accumulated prior to the exception is written to the output before shutting down.

Notably, this catches timeout errors when the device is yanked, reducing data loss.