### PR TITLE
Add option to shuffle hop channels

### DIFF
--- a/soapypower/__main__.py
+++ b/soapypower/__main__.py
@@ -271,6 +271,8 @@ def setup_argument_parser():
                              help='shape parameter of window function (required for kaiser and tukey windows)')
     other_title.add_argument('--fft-overlap', metavar='PERCENT', type=float, default=50,
                              help='Welch\'s method overlap between segments (default: %(default)s)')
+    other_title.add_argument('--random', action='store_true',
+                             help='randomly shuffle frequency hops')
 
     return parser
 
@@ -370,7 +372,7 @@ def main():
         remove_dc=args.remove_dc, detrend=args.detrend if args.detrend != 'none' else None,
         lnb_lo=args.lnb_lo, tune_delay=args.tune_delay, reset_stream=args.reset_stream,
         base_buffer_size=args.buffer_size, max_buffer_size=args.max_buffer_size,
-        max_threads=args.max_threads, max_queue_size=args.max_queue_size
+        max_threads=args.max_threads, max_queue_size=args.max_queue_size, random_hops=args.random
     )
 
 

--- a/soapypower/power.py
+++ b/soapypower/power.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-import sys, time, datetime, math, logging, signal
+import sys, time, datetime, math, logging, signal, random, os
 
 import numpy
 import simplesoapy
@@ -271,7 +271,7 @@ class SoapyPower:
 
         return (psd_future, acq_time_start, acq_time_stop)
 
-    def sweep(self, min_freq, max_freq, bins, repeats, runs=0, time_limit=0, overlap=0,
+    def sweep(self, min_freq, max_freq, bins, repeats, runs=0, time_limit=0, overlap=0, random_hops=False,
               fft_window='hann', fft_overlap=0.5, crop=False, log_scale=True, remove_dc=False, detrend=None, lnb_lo=0,
               tune_delay=0, reset_stream=False, base_buffer_size=0, max_buffer_size=0, max_threads=0, max_queue_size=0):
         """Sweep spectrum using frequency hopping"""
@@ -282,8 +282,13 @@ class SoapyPower:
             reset_stream=reset_stream, max_threads=max_threads, max_queue_size=max_queue_size
         )
 
+        if random_hops:
+            random.seed(os.urandom(16))
+
         try:
             freq_list = self.freq_plan(min_freq - lnb_lo, max_freq - lnb_lo, bins, overlap)
+            if random:
+                random.shuffle(freq_list)
             t_start = time.time()
             run = 0
             while not _shutdown and (runs == 0 or run < runs):


### PR DESCRIPTION
This PR adds the `--random` option, which if specified randomizes the order that channels are hopped through.